### PR TITLE
fix tiny typo

### DIFF
--- a/_posts/2014-01-02-open-science-literature-highlights.md
+++ b/_posts/2014-01-02-open-science-literature-highlights.md
@@ -29,7 +29,7 @@ This set of interviews from Nature's Careers column this summer might make a mor
 
 ### open code: 
 
-I my opinion this is the upcoming big issue.  Of course open source has a long history in academia, but publishers and funders have paid a lot more attention to open data and open access (Creation of repositories like Dryad; required data deposition by many leading journals; funder's support of data synthesis initiatives, etc).  Interest in the potential for open code and concerns about reliability of increasingly software-driven results seem to be growing, this article does a good job providing concrete examples:
+In my opinion this is the upcoming big issue.  Of course open source has a long history in academia, but publishers and funders have paid a lot more attention to open data and open access (Creation of repositories like Dryad; required data deposition by many leading journals; funder's support of data synthesis initiatives, etc).  Interest in the potential for open code and concerns about reliability of increasingly software-driven results seem to be growing, this article does a good job providing concrete examples:
 
 - Ince, D. C., Hatton, L. & Graham-Cumming, J. 2012 The case for open computer programs. Nature 482, 485–488. (doi:[10.1038/nature10836](http://doi.org/10.1038/nature10836))
 


### PR DESCRIPTION
Nice collection, thanks for sharing it. By the way, I thought that by clicking on the the SHA hash in your blog's right sidebar for [this post](http://www.carlboettiger.info/2014/01/02/open-science-literature-highlights.html) would take me to the source of that post for convienent editing. But the hash was 90ecb182cfe862b87eb74c06333fa9d9b403e3fd which linked me to [a different blog entry](https://github.com/cboettig/labnotebook/commit/90ecb182cfe862b87eb74c06333fa9d9b403e3fd/_posts/2014-01-02-open-science-literature-highlights.md). Having a quick survey of other posts on your blog, the SHA hash link often doesn't link to the code for the post. Am I misunderstanding the meaning of that SHA hash link?
