### PR TITLE
Fix link to fluctuationDomains

### DIFF
--- a/content/pubs.md
+++ b/content/pubs.md
@@ -235,7 +235,7 @@ css: ["vita.css"]
     in adaptive evolution. ReScience C 6, 1, #15, 
     <https://rescience.github.io/bibliography/Boettiger_2020.html>,
     [doi:10.5281/zenodo.4081202](https://doi.org/10.5281/zenodo.4081202),
-    [code](https://github.com/cboettig/fluctationDomains)
+    [code](https://github.com/cboettig/fluctuationDomains)
 
 38. Caleb Scoville, Melissa Chapman, Razvan Amironesei, __Carl Boettiger__ (2021). 
     Algorithmic conservation in a changing climate.

--- a/content/vita.md
+++ b/content/vita.md
@@ -256,7 +256,7 @@ css: ["vita.css"]
     in adaptive evolution. ReScience C 6, 1, #15, 
     <https://rescience.github.io/bibliography/Boettiger_2020.html>,
     [doi:10.5281/zenodo.4081202](https://doi.org/10.5281/zenodo.4081202),
-    [code](https://github.com/cboettig/fluctationDomains)
+    [code](https://github.com/cboettig/fluctuationDomains)
 
 38. Caleb Scoville, Melissa Chapman, Razvan Amironesei, __Carl Boettiger__ (2021). 
     Algorithmic conservation in a changing climate.


### PR DESCRIPTION
Hi @cboettig 👋 
The link to your `fluctuationDomains` had a typo on your website so I've corrected it.
One additional issue is that the link has the same typo also in the [`fluctuationDomains` repo](https://github.com/cboettig/fluctuationDomains/search?q=fluctationDomains) but I'm not sure what to do about it.